### PR TITLE
Require Python >= 3.6.1 for PySlice_AdjustIndices

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha1: 8920e4094470ff93f79e257c37c46f5cd0bff7ab  # [not win]
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -23,6 +23,7 @@ requirements:
     - jom  # [win]
   run:
     - python
+    - python >=3.6.1  # [py>=36]
     - qt 5.6.*
     - sip 4.18
 


### PR DESCRIPTION
with python 3.6.0 from miniconda-latest: PyQt5/QtCore.so: undefined symbol: PySlice_AdjustIndices, this is a symbol that was added in python 3.6.1, which is used for build