### PR TITLE
Ensure prefix is picked up on Windows so pyrcc5 runs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,4 +51,5 @@ build: off
 test_script:
     - conda.exe build recipe -m .ci_support\%CONFIG%.yaml
 deploy_script:
+    - set "GIT_BRANCH=%APPVEYOR_REPO_BRANCH%"
     - cmd: upload_package .\ .\recipe .ci_support\%CONFIG%.yaml

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -33,6 +33,7 @@ jobs:
 
   - script: |
         export CI=azure
+        export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         .azure-pipelines/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -74,6 +74,7 @@ jobs:
 
   - script: |
       source activate base
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
     displayName: Upload recipe
     env:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -99,6 +99,7 @@ jobs:
       condition: not(contains(variables['CONFIG'], 'vs2008'))
 
     - script: |
+        set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         upload_package .\ .\recipe .ci_support\%CONFIG%.yaml
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -64,6 +64,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
+           -e GIT_BRANCH \
+           -e UPLOAD_ON_BRANCH \
            -e CI \
            $DOCKER_IMAGE \
            bash \

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,18 @@
 meta.yaml text eol=lf
 build.sh text eol=lf
 bld.bat text eol=crlf
+
+# github helper pieces to make some files not show up in diffs automatically
+.azure-pipelines/* linguist-generated=true
+.circleci/* linguist-generated=true
+.github/* linguist-generated=true
+.travis/* linguist-generated=true
+.appveyor.yml linguist-generated=true 
+.gitattributes linguist-generated=true 
+.gitignore linguist-generated=true
+.travis.yml linguist-generated=true
+LICENSE.txt linguist-generated=true 
+README.md linguist-generated=true 
+azure-pipelines.yml linguist-generated=true
+build-locally.py linguist-generated=true
+shippable.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -102,7 +102,12 @@ Current build status
       </details>
     </td>
   </tr>
-![ppc64le disabled](https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg)
+  <tr>
+    <td>Linux_ppc64le</td>
+    <td>
+      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
+    </td>
+  </tr>
 </table>
 
 Current release info

--- a/recipe/0004-configure-winbat.patch
+++ b/recipe/0004-configure-winbat.patch
@@ -1,0 +1,11 @@
+--- configure.py.orig2	2019-09-05 10:49:08.868149072 +1000
++++ configure.py	2019-09-05 10:49:15.728238744 +1000
+@@ -1763,7 +1763,7 @@
+     wf = open_for_writing(wrapper)
+ 
+     if target_config.py_platform == 'win32':
+-        wf.write('@%s -m %s %%1 %%2 %%3 %%4 %%5 %%6 %%7 %%8 %%9\n' % (exe, module))
++        wf.write('@ %s -m %s %%1 %%2 %%3 %%4 %%5 %%6 %%7 %%8 %%9\n' % (exe, module))
+     else:
+         wf.write('#!/bin/sh\n')
+         wf.write('exec %s -m %s ${1+"$@"}\n' % (exe, module))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,9 +86,6 @@ test:
     - PyQt5.QtXmlPatterns
   commands:
     - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'python pyqt_test.py'  # [linux]
-    # For some reason "pyrcc5 -h" returns exit code of 1
-    - pyrcc5 -h; test $? -eq 1 && true || false  # [not win]
-    - pyrcc5 -h & if %ERRORLEVEL% EQU 1 EXIT 0 || EXIT 1  # [win]
 
 about:
   home: http://www.riverbankcomputing.co.uk/software/pyqt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,7 +86,9 @@ test:
     - PyQt5.QtXmlPatterns
   commands:
     - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'python pyqt_test.py'  # [linux]
-    - pyrcc5 -h
+    # For some reason "pyrcc5 -h" returns exit code of 1
+    - pyrcc5 -h; test $? -eq 1 && true || false  # [not win]
+    - pyrcc5 -h & if %ERRORLEVEL% EQU 1 EXIT 0 || EXIT 1  # [win]
 
 about:
   home: http://www.riverbankcomputing.co.uk/software/pyqt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
   sha1: 058c5b37981b515cc4e16faa04a4a6d8892cdaa9
   patches:
     - 0003-configure.patch
+    - 0004-configure-winbat.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and py27]
   skip: true  # [ppc64le]
   run_exports:
@@ -85,6 +86,7 @@ test:
     - PyQt5.QtXmlPatterns
   commands:
     - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'python pyqt_test.py'  # [linux]
+    - pyrcc5 -h
 
 about:
   home: http://www.riverbankcomputing.co.uk/software/pyqt


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

xref: https://github.com/conda-forge/qgis-feedstock/pull/86

In `pyqt` 5.9, pyrcc5 is now a .bat file. The path to Python is written into it during the build, but because there is no space after the `@` symbol (I think) conda-build isn't picking up that this needs to be replaced at install time like it does on Unix.

I've also added a test that `pyrcc5` actually runs.
