### PR TITLE
Remove path to Python in .bat files

### DIFF
--- a/recipe/0004-configure-winbat.patch
+++ b/recipe/0004-configure-winbat.patch
@@ -1,11 +1,11 @@
---- configure.py.orig2	2019-09-05 10:49:08.868149072 +1000
-+++ configure.py	2019-09-05 10:49:15.728238744 +1000
+--- configure.py.orig	2019-09-09 08:01:05.922231200 +1000
++++ configure.py	2019-09-09 08:01:13.156085000 +1000
 @@ -1763,7 +1763,7 @@
      wf = open_for_writing(wrapper)
  
      if target_config.py_platform == 'win32':
 -        wf.write('@%s -m %s %%1 %%2 %%3 %%4 %%5 %%6 %%7 %%8 %%9\n' % (exe, module))
-+        wf.write('@ %s -m %s %%1 %%2 %%3 %%4 %%5 %%6 %%7 %%8 %%9\n' % (exe, module))
++        wf.write('@%s -m %s %%1 %%2 %%3 %%4 %%5 %%6 %%7 %%8 %%9\n' % (os.path.basename(exe), module))
      else:
          wf.write('#!/bin/sh\n')
          wf.write('exec %s -m %s ${1+"$@"}\n' % (exe, module))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0004-configure-winbat.patch  # [win]
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win and py27]
   skip: true  # [ppc64le]
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,8 @@ source:
   sha1: 058c5b37981b515cc4e16faa04a4a6d8892cdaa9
   patches:
     - 0003-configure.patch
-    - 0004-configure-winbat.patch
+    # remove build path from .bat
+    - 0004-configure-winbat.patch  # [win]
 
 build:
   number: 3


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

xref: https://github.com/conda-forge/qgis-feedstock/pull/86

#63 didn't fix the issue of the build path being embedded in the `.bat` files. This is another attempt and it simply removes the path from the Python command so it can be found in any environment. Any better suggestions of how to fix Windows properly greatly received!