### PR TITLE
Update sip to 4.19.24 to match sip-feedstock

### DIFF
--- a/recipe/0002-link-conda-qt-libs-win.patch
+++ b/recipe/0002-link-conda-qt-libs-win.patch
@@ -1,0 +1,14 @@
+diff --git a/siputils.py b/siputils.py
+index a29300d..89fe76d 100644
+--- a/siputils.py
++++ b/siputils.py
+@@ -887,6 +887,9 @@ class Makefile:
+         if qt5_rename:
+             lib = "Qt5" + lib[2:]
+ 
++        if sys.platform == "win32":
++            lib += '_conda'
++
+         return lib
+ 
+     def optional_list(self, name):

--- a/recipe/build-pyqt-sip.sh
+++ b/recipe/build-pyqt-sip.sh
@@ -1,16 +1,8 @@
 #!/bin/bash
 
-set -e # Abort on error.
-
-declare -a _extra_modules
 # Avoid Xcode
 if [[ ${HOST} =~ .*darwin.* ]]; then
   PATH=${PREFIX}/bin/xc-avoidance:${PATH}
-    _extra_modules+=(--enable)
-    _extra_modules+=(QtMacExtras)
-else
-    _extra_modules+=(--enable)
-    _extra_modules+=(QtX11Extras)
 fi
 
 
@@ -36,7 +28,8 @@ export PATH=${PWD}/bin:${PATH}
 echo -e "\n************** start building a private sip module **************\n"
 #echo "PWD: ${SRC_DIR}"
 cd sip
-$PYTHON configure.py --sip-module PyQt5.sip
+export LINK=${CC}
+$PYTHON configure.py --sip-module PyQt5.sip --sysroot=${PREFIX}
 make -j${CPU_COUNT} # ${VERBOSE_AT}
 make install
 cd ../

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "5.12.3" %}
+{% set sipversion = "4.19.24" %}
 
 package:
   name: pyqt_split
@@ -15,12 +16,11 @@ source:
       - qt5_dll.diff
     folder: pyqt5
 
-  - url: https://distfiles.macports.org/py-sip/sip-4.19.18.tar.gz
-    sha1: d001eb00f6dae26a952770e805b1519f61cae77d
+  - url: https://www.riverbankcomputing.com/static/Downloads/sip/{{ sipversion }}/sip-{{ sipversion }}.tar.gz
+    sha256: edcd3790bb01938191eef0f6117de0bf56d1136626c0ddb678f3a558d62e41e5
     patches:
       - 0001-Do-not-override-CC-CXX-LINK-in-sipgen-Makefile.patch
-      # AttributeError: module 'distutils.sysconfig' has no attribute 'get_config_h_filename'
-      - sip-get_config_h_filename.patch
+      - 0002-link-conda-qt-libs-win.patch  # [win]
     folder: sip
 
   - url: https://distfiles.macports.org/py-pyqt5/PyQtWebEngine_gpl-5.12.1.tar.gz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ source:
     folder: pyqtcharts
 
 build:
-  number: 6
+  number: 7
   skip: true  # [win and py27]
   skip: true  # [ppc64le]
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This is just an update to the sip version to match the sip-feedstock version. Hopefully this will solve the conflicts for projects that end up pulling in both `pyqt` and `sip`. 

Long term solution may be to use sip-feedstock instead of bundling out own.
