### PR TITLE
Pin pyqt-builder to <1.16.0 to maintain compatibility with PyQt5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,6 +3,7 @@
 {% set pyqt5_sip_version = "12.17.0" %}
 {% set webengine_version = "5.15.7" %}
 {% set charts_version = "5.15.7" %}
+{% set pyqt_builder_version = "<1.16.0" %}
 
 
 package:
@@ -29,7 +30,7 @@ source:
     folder: pyqt_charts
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: pyqt5-sip
@@ -70,19 +71,19 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
-        - jom                                # [win]
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - pyqt-builder                           # [build_platform != target_platform]
-        - sip {{ sip_version }}                  # [build_platform != target_platform]
+        - jom                                      # [win]
+        - python                                   # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}       # [build_platform != target_platform]
+        - pyqt-builder {{ pyqt_builder_version }}  # [build_platform != target_platform]
+        - sip {{ sip_version }}                    # [build_platform != target_platform]
         - make
       host:
         - python
         - pip
         - setuptools
-        - sip {{ sip_version }}                  # [build_platform == target_platform]
+        - sip {{ sip_version }}                    # [build_platform == target_platform]
         - toml
-        - pyqt-builder                           # [build_platform == target_platform]
+        - pyqt-builder {{ pyqt_builder_version }}  # [build_platform == target_platform]
         - packaging
         - qt-main
         - libgl-devel                            # [linux]
@@ -145,19 +146,19 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
-        - jom                                    # [win]
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - pyqt-builder                           # [build_platform != target_platform]
-        - sip {{ sip_version }}                  # [build_platform != target_platform]
+        - jom                                      # [win]
+        - python                                   # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}       # [build_platform != target_platform]
+        - pyqt-builder {{ pyqt_builder_version }}  # [build_platform != target_platform]
+        - sip {{ sip_version }}                    # [build_platform != target_platform]
         - make
       host:
         - python
         - pip
         - setuptools
-        - sip {{ sip_version }}                  # [build_platform == target_platform]
+        - sip {{ sip_version }}                    # [build_platform == target_platform]
         - toml
-        - pyqt-builder                           # [build_platform == target_platform]
+        - pyqt-builder {{ pyqt_builder_version }}  # [build_platform == target_platform]
         - packaging
         - pyqt
         - qt-main
@@ -200,19 +201,19 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - {{ stdlib('c') }}
-        - jom                                    # [win]
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - pyqt-builder                           # [build_platform != target_platform]
-        - sip {{ sip_version }}                  # [build_platform != target_platform]
+        - jom                                      # [win]
+        - python                                   # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}       # [build_platform != target_platform]
+        - pyqt-builder {{ pyqt_builder_version }}  # [build_platform != target_platform]
+        - sip {{ sip_version }}                    # [build_platform != target_platform]
         - make
       host:
         - python
         - pip
         - setuptools
-        - sip {{ sip_version }}                  # [build_platform == target_platform]
+        - sip {{ sip_version }}                    # [build_platform == target_platform]
         - toml
-        - pyqt-builder                           # [build_platform == target_platform]
+        - pyqt-builder {{ pyqt_builder_version }}  # [build_platform == target_platform]
         - packaging
         - qt-main
         - pyqt


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

As advised in https://github.com/conda-forge/pyqt-builder-feedstock/pull/22 to separate v5 and v6 against pyqt-builder