### PR TITLE
Enable PyQt6 Vulkan bindings on macOS

### DIFF
--- a/recipe/build-pyqt.sh
+++ b/recipe/build-pyqt.sh
@@ -55,6 +55,10 @@ else
   ln -s ${PREFIX}/bin/qmake6 ${PREFIX}/bin/qmake
 fi
 
+# Ensure that SIP's qmake-based feature probes can find headers supplied by
+# host dependencies, including vulkan/vulkan.h on macOS.
+export CPATH="${PREFIX}/include${CPATH:+:${CPATH}}"
+
 $SIP_COMMAND \
 --verbose \
 --confirm-license \
@@ -70,7 +74,7 @@ if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then
   mv Makefile.temp Makefile
 fi
 
-CPATH=$PREFIX/include make -j$CPU_COUNT
+make -j$CPU_COUNT
 make install
 
 # ---- Build and install the Qt Designer plugin -------------------------

--- a/recipe/build-pyqt.sh
+++ b/recipe/build-pyqt.sh
@@ -41,9 +41,6 @@ fi
 source ${RECIPE_DIR}/setup-cross-compile.sh
 
 if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" == "1" ]]; then
-  # Vulkan bindings fail when the cross target QtGui headers do not expose the
-  # QVulkan* API expected by the generated SIP sources.
-  EXTRA_FLAGS="${EXTRA_FLAGS} --disabled-feature=PyQt_Vulkan"
   # OpenGL ES2 detection is unreliable when probing the target Qt during cross
   # builds and can leave generated QtOpenGL sources referencing missing ES2
   # types on arm64 targets.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "6.11.0" %}
+{% set qt_version = "6.11.1" %}
 {% set sip_version = "6.15.3" %}
 {% set pyqt6_sip_version = "13.10.0" %}
 {% set webengine_version = "6.8.0" %}
@@ -76,10 +77,10 @@ outputs:
         - cross-python_{{ target_platform }}       # [build_platform != target_platform]
         - pyqt-builder {{ pyqt_builder_version }}  # [build_platform != target_platform]
         - sip {{ sip_version }}                    # [build_platform != target_platform]
-        - qt6-main {{ version }}                   # [build_platform != target_platform]
-        - qt6-multimedia {{ version }}             # [build_platform != target_platform]
-        - qt6-serialport {{ version }}             # [build_platform != target_platform]
-        - qt6-positioning {{ version }}            # [build_platform != target_platform]
+        - qt6-main {{ qt_version }}                # [build_platform != target_platform]
+        - qt6-multimedia {{ qt_version }}          # [build_platform != target_platform]
+        - qt6-serialport {{ qt_version }}          # [build_platform != target_platform]
+        - qt6-positioning {{ qt_version }}         # [build_platform != target_platform]
         - make
         - patchelf                                  # [linux]
         - libsystemd                                # [linux]
@@ -91,11 +92,11 @@ outputs:
         - toml
         - pyqt-builder {{ pyqt_builder_version }}  # [build_platform == target_platform]
         - packaging
-        - qt6-main {{ version }}
-        - qt6-multimedia {{ version }}
-        - qt6-serialport {{ version }}
-        - qt6-positioning {{ version }}
-        - vulkan-headers                         # [build_platform == target_platform]
+        - qt6-main {{ qt_version }}
+        - qt6-multimedia {{ qt_version }}
+        - qt6-serialport {{ qt_version }}
+        - qt6-positioning {{ qt_version }}
+        - libvulkan-headers                     # [build_platform == target_platform]
         - libsystemd                             # [linux]
         - libgl-devel                            # [linux]
         - libegl-devel                           # [linux]
@@ -169,7 +170,7 @@ outputs:
         - cross-python_{{ target_platform }}       # [build_platform != target_platform]
         - pyqt-builder {{ pyqt_builder_version }}  # [build_platform != target_platform]
         - sip {{ sip_version }}                    # [build_platform != target_platform]
-        - qt6-main {{ version }}                   # [build_platform != target_platform]
+        - qt6-main {{ qt_version }}                # [build_platform != target_platform]
         - make
       host:
         - python
@@ -180,8 +181,8 @@ outputs:
         - pyqt-builder {{ pyqt_builder_version }}  # [build_platform == target_platform]
         - packaging
         - pyqt6
-        - qt6-main {{ version }}
-        - qt6-webengine {{ version }}            # [build_platform != target_platform]
+        - qt6-main {{ qt_version }}
+        - qt6-webengine {{ qt_version }}         # [build_platform != target_platform]
         - libgl-devel                            # [linux]
         - libegl-devel                           # [linux]
         - libopengl-devel                        # [linux]
@@ -225,8 +226,8 @@ outputs:
         - cross-python_{{ target_platform }}       # [build_platform != target_platform]
         - pyqt-builder {{ pyqt_builder_version }}  # [build_platform != target_platform]
         - sip {{ sip_version }}                    # [build_platform != target_platform]
-        - qt6-main {{ version }}                   # [build_platform != target_platform]
-        - qt6-charts {{ version }}                 # [build_platform != target_platform]
+        - qt6-main {{ qt_version }}                # [build_platform != target_platform]
+        - qt6-charts {{ qt_version }}              # [build_platform != target_platform]
         - make
       host:
         - python
@@ -236,8 +237,8 @@ outputs:
         - toml
         - pyqt-builder {{ pyqt_builder_version }}  # [build_platform == target_platform]
         - packaging
-        - qt6-main {{ version }}
-        - qt6-charts {{ version }}
+        - qt6-main {{ qt_version }}
+        - qt6-charts {{ qt_version }}
         - pyqt6
         - libgl-devel                            # [linux]
         - libegl-devel                           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ outputs:
         - qt6-multimedia {{ qt_version }}
         - qt6-serialport {{ qt_version }}
         - qt6-positioning {{ qt_version }}
-        - libvulkan-headers                     # [build_platform == target_platform]
+        - libvulkan-headers
         - libsystemd                             # [linux]
         - libgl-devel                            # [linux]
         - libegl-devel                           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     folder: pyqt_charts
 
 build:
-  number: 2
+  number: 3
   skip:
     - true  # [linux and ppc64le]
 
@@ -95,6 +95,7 @@ outputs:
         - qt6-multimedia {{ version }}
         - qt6-serialport {{ version }}
         - qt6-positioning {{ version }}
+        - vulkan-headers                         # [build_platform == target_platform]
         - libsystemd                             # [linux]
         - libgl-devel                            # [linux]
         - libegl-devel                           # [linux]
@@ -143,6 +144,7 @@ outputs:
         - PyQt6.QtSerialPort
         - PyQt6.QtPositioning
       commands:
+        - python -c "from PyQt6.QtGui import QVulkanInstance, QWindow; assert hasattr(QWindow, 'setVulkanInstance')"  # [build_platform == target_platform]
         - QT_QPA_PLATFORM=offscreen python pyqt_test.py  # [linux and build_platform == target_platform]
         - pyuic6 --version  # [not win]
         - test -f "${PREFIX}/lib/qt6/plugins/designer/libpyqt6${SHLIB_EXT}"  # [unix]


### PR DESCRIPTION
PyQt6's `QVulkanInstance` bindings are conditional on Qt's Vulkan feature and on Vulkan headers being visible when SIP generates the QtGui module.

This update:

- builds PyQt6 6.11.0 against Qt 6.11.1, the current Qt patch release in the feedstock;
- makes `libvulkan-headers` available to native and cross-build host environments;
- exports `$PREFIX/include` through `CPATH` before SIP runs, allowing qmake-based feature probes to find `vulkan/vulkan.h`;
- removes the macOS cross-build `PyQt_Vulkan` disable now that the companion Qt package exposes the target Vulkan API;
- adds a native regression test for `QVulkanInstance` and `QWindow.setVulkanInstance`;
- increments the build number from 2 to 3.

The Qt 6.11.1 dependency is intentionally separate from the PyQt 6.11.0 release version. Both use the Qt 6.11 ABI line.

This PR depends on the Vulkan-enabled macOS Qt package proposed in:

https://github.com/conda-forge/qt-main-feedstock/pull/406

Local macOS ARM64 validation was completed on an Apple M1 Pro against the companion Qt build 2:

- all three outputs—`pyqt6-sip`, `pyqt6`, and `pyqt6-charts`—built successfully;
- all existing package tests passed;
- SIP enabled `PyQt_Vulkan`;
- the Vulkan binding import and API assertion passed;
- `QVulkanInstance.create()` succeeded through the packaged MoltenVK ICD;
- a Cocoa Vulkan window returned a non-null surface;
- a packaged downstream Datoviz Qt bridge loaded with matching Qt 6.11.1 runtimes and completed a hosted rendering smoke.

The local primary artifact was:

`pyqt6-6.11.0-py310h8bf5152_3.conda`

SHA-256:

`932166fcb6bd54a4d4beec9226bd452dc98729cabcdbd2709710dc9377410f0c`

The current macOS CI ran before Vulkan-enabled Qt build 2 was published. All Windows jobs passed. Native macOS x86-64 jobs therefore built without `QVulkanInstance` and failed the new package test, while cross-built macOS ARM64 jobs generated the Vulkan bindings but could not find `qvulkaninstance.h` in the currently published target Qt package. The compiler already includes the target QtGui directory; the missing published header—not another include flag—is the blocker.

The macOS matrix should be restarted after Qt 6.11.1 build 2 is published for both macOS architectures.

Downstream context: https://github.com/datoviz/datoviz/issues/42

Checklist

- [x] Used a personal fork of the feedstock
- [x] Bumped the build number
- [x] Used current `libvulkan-headers`
- [x] Enabled Vulkan bindings for native and cross-built macOS targets
- [x] Preserved the existing license packaging
- [x] Completed the full native macOS ARM64 package build and tests
- [x] Completed isolated Vulkan instance, Cocoa surface, and downstream rendering tests
- [ ] Rerun macOS CI after the companion Qt build 2 is published
